### PR TITLE
Feature soeyi

### DIFF
--- a/lib/decorator.ts
+++ b/lib/decorator.ts
@@ -1,5 +1,7 @@
 import * as _ from 'lodash';
 
+
+import { IResp } from './swaggerJSON';
 /**
  * used for building swagger docs object
  */
@@ -63,7 +65,7 @@ const middlewares = middlewares => (target, name, descriptor) => {
   return descriptor;
 };
 
-const responses = (responses = { 200: { description: 'success' } }) => (target, name, descriptor) => {
+const responses = (responses: IResp = { 200: { description: 'success' } }) => (target, name, descriptor) => {
   descriptor.value.responses = responses;
   _addToApiObject(target, name, apiObjects, { responses });
   return descriptor;
@@ -93,5 +95,7 @@ const body = params('body');
 // formData params
 const formData = params('formData');
 
-export { request, summary, params, desc, description, query, path, body, tags,
-  apiObjects, middlewares, formData, responses };
+export {
+  request, summary, params, desc, description, query, path, body, tags,
+  apiObjects, middlewares, formData, responses
+};

--- a/lib/swaggerJSON.ts
+++ b/lib/swaggerJSON.ts
@@ -15,9 +15,13 @@ export interface WrapperOptions {
   makeSwaggerRouter?: boolean,
   [param: string]: any,
 }
+
+export interface IResp {
+  [param: string]: object
+}
 const swaggerJSON = (options: WrapperOptions, apiObjects) => {
-  
-  const {title = 'API DOC', description ='API DOC', version = '1.0.0',prefix = '', swaggerOptions = {}} = options;
+
+  const { title = 'API DOC', description = 'API DOC', version = '1.0.0', prefix = '', swaggerOptions = {} } = options;
 
   const swaggerJSON = init(title, description, version, swaggerOptions);
 
@@ -39,7 +43,7 @@ const swaggerJSON = (options: WrapperOptions, apiObjects) => {
           description: 'success'
         }
       };
-      const responses : any = value.responses
+      const responses: IResp = value.responses
         ? value.responses
         : defaultResp;
       const {

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -58,6 +58,9 @@ export default function (input, expect) {
         input[key] = String(input[key]);
         return;
       }
+      if (Array.isArray(expect[key].enum) && expect[key].enum.length) {
+        if (!expect[key].enum.includes(input[key])) throw new InputError(key)
+      }
     }
     // forth check the object type
     if (input[key] !== undefined && expect[key].type === 'object') {

--- a/test/fixtures/apps/swagger-decorator-test/app/controller/home.ts
+++ b/test/fixtures/apps/swagger-decorator-test/app/controller/home.ts
@@ -1,5 +1,5 @@
 import { Controller, Context } from 'egg';
-import {request, tags, middlewares} from '../../../../../../lib';
+import { request, tags, middlewares, responses } from '../../../../../../lib';
 
 const tag = tags(['Home']);
 
@@ -13,6 +13,17 @@ export default class HomeController extends Controller {
   @request('GET', '/')
   @middlewares([logTime()])
   @tag
+  @responses({
+    200: {
+      description: 'success',
+      schema: {
+        type: 'object',
+        properties: {
+          msg: { type: 'string', example: 'here is a msg' },
+        }
+      }
+    }
+  })
   public async index() {
     const { ctx, service } = this;
     ctx.body = await service.test.sayHi('egg');

--- a/test/fixtures/apps/swagger-decorator-test/app/controller/test.ts
+++ b/test/fixtures/apps/swagger-decorator-test/app/controller/test.ts
@@ -17,17 +17,17 @@ const resp = {
   }
 }
 
-export default class Test extends Controller{
+export default class Test extends Controller {
   @request('get', '/users')
   @description('get user list')
   @testTag
-  @middlewares(async (ctx: Context, next) => {ctx.logger.info('mid'); await next()})
+  @middlewares(async (ctx: Context, next) => { ctx.logger.info('mid'); await next() })
   @query({
     type: { type: 'string', required: false, default: 'a', description: 'type' }
   })
   public async getUsers() {
     const { ctx } = this;
-    const users = [{user1: {name: 'xxx'}}]
+    const users = [{ user1: { name: 'xxx' } }]
     ctx.body = { users };
   }
 
@@ -50,5 +50,17 @@ export default class Test extends Controller{
   public async postUser() {
     const body = this.ctx.request.body;
     this.ctx.body = body;
+  }
+
+  @request('get', '/enum')
+  @testTag
+  @query({
+    role: { type: 'string', enum: ['1', '2', '3'], required: true }
+  })
+  @responses(resp)
+  public async testEnum() {
+    const { ctx } = this;
+    console.log(ctx.query);
+    ctx.body = { msg: 'enum passed' };
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -229,6 +229,43 @@ describe('test/app/lib.test.ts', () => {
           assert(err.message === "incorrect field: 'foo', please check again!")
         }
       });
+      
+      it('should throw error when enum not a array', () => {
+        const input = { foo: '1' };
+        const expect = {
+          foo: { type: 'string', enum: 'enum is a string' }
+        };
+        try {
+          validate(input, expect);
+        } catch (err) {
+          assert(err.message === "incorrect field: 'foo', please check again!")
+        }
+      })
+
+      it('should throw error when enum is an empty array', () => {
+        const input = { foo: '1' };
+        const expect = {
+          foo: { type: 'string', enum: [] }
+        };
+        try {
+          validate(input, expect);
+        } catch (err) {
+          assert(err.message === "incorrect field: 'foo', please check again!")
+        }
+      })
+
+
+      it('should throw error when enum doesnt includes input an empty array', () => {
+        const input = { foo: '1' };
+        const expect = {
+          foo: { type: 'string', enum: ['2', '3'] }
+        };
+        try {
+          validate(input, expect);
+        } catch (err) {
+          assert(err.message === "incorrect field: 'foo', please check again!")
+        }
+      })
     });
   });
 });


### PR DESCRIPTION
### Reponses Interface definition
 
 
#### when direct use : 
  
```
  @responses({
    200: {
      description: 'success',
      schema: {
        type: 'object',
        properties: {
          msg: { type: 'string', example: 'here is a msg' },
        }
      }
    }
  })
```

will throw a typescript error: 
`throw new TSError(formatDiagnostics(diagnosticList, cwd, ts, lineOffset))`

`'schema' does not exist in type '{ description: string; }'`


### Add enum check

```
@query({
    type:'string',enum:['1','2','3']
})
```


### Unittest added


